### PR TITLE
Update integration workflow to use vars for LOYALTY_API_ENDPOINT_URL

### DIFF
--- a/.github/workflows/integration-v4.yml
+++ b/.github/workflows/integration-v4.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   COMPOSER_FLAGS: "--ansi --no-interaction --no-progress --prefer-dist"
-  LOYALTY_API_ENDPOINT_URL: ${{ secrets.LOYALTY_API_ENDPOINT_URL }}
+  LOYALTY_API_ENDPOINT_URL: ${{ vars.LOYALTY_API_ENDPOINT_URL }}
   LOYALTY_API_CLIENT_ID: ${{ secrets.LOYALTY_API_CLIENT_ID }}
   LOYALTY_API_ADMIN_KEY: ${{ secrets.LOYALTY_API_ADMIN_KEY }}
 
@@ -37,7 +37,9 @@ jobs:
           php-version: "${{ matrix.php-version }}"
           ini-values: variables_order=EGPCS
         env:
-          BITRIX24_PHP_SDK_PLAYGROUND_WEBHOOK: ${{ secrets.BITRIX24_PHP_SDK_PLAYGROUND_WEBHOOK }}
+          LOYALTY_API_ENDPOINT_URL: ${{ vars.LOYALTY_API_ENDPOINT_URL }}
+          LOYALTY_API_CLIENT_ID: ${{ secrets.LOYALTY_API_CLIENT_ID }}
+          LOYALTY_API_ADMIN_KEY: ${{ secrets.LOYALTY_API_ADMIN_KEY }}
 
       - name: "Install dependencies"
         run: |


### PR DESCRIPTION
The integration workflow file (.github/workflows/integration-v4.yml) was updated to use vars instead of secrets for the LOYALTY_API_ENDPOINT_URL. This change improves flexibility by allowing the URL to be updated more easily in the workflow runtime environment.