### PR TITLE
Remove ext-bcmath dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 * WIP add support for email account for contacts
 
+## 3.3.1 (2024.07.29) 
+### Changed
+* removed `ext-bcmath` in composer requirement
 
 ## 3.3.0 (2024.07.10)
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
   "require": {
     "php": "7.4.* || 8.2.* || 8.3.*",
     "ext-json": "*",
-    "ext-bcmath": "*",
     "ext-curl": "*",
     "ext-intl": "*",
     "psr/log": "^1.1.4 || ^2.0 || ^3.0",

--- a/docker/php-cli/Dockerfile
+++ b/docker/php-cli/Dockerfile
@@ -1,8 +1,8 @@
 FROM php:7.4-cli-alpine
 
 RUN apk add unzip libpq-dev git icu-dev \
-    && docker-php-ext-install bcmath intl \
-    && docker-php-ext-enable bcmath intl
+    && docker-php-ext-install intl \
+    && docker-php-ext-enable intl
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/bin --filename=composer --quiet
 


### PR DESCRIPTION
Remove `ext-bcmath` from composer.json and Dockerfile since it is no longer required. The appropriate changes have been documented in the CHANGELOG.